### PR TITLE
refac:一覧のロジックをモデルに移行

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -39,11 +39,7 @@ class RoomsController < ApplicationController
   end
 
   def index
-    @rooms = current_user.rooms
-                         .joins(:proverb)
-                         .merge(Proverb.where.not(status: :completed))
-                         .includes(:users, :room_users)
-                         .order(created_at: :desc)
+    @rooms = current_user.in_progress_proverb_rooms
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,6 +93,14 @@ class User < ApplicationRecord
     uid
   end
 
+  def in_progress_proverb_rooms
+    rooms
+      .joins(:proverb)
+      .merge(Proverb.where.not(status: :completed))
+      .includes(:users, :room_users)
+      .order(created_at: :desc)
+  end
+
   private
   def self.ransackable_attributes(auth_object = nil)
     %w[ name ]


### PR DESCRIPTION
rooms_controllerのindexメソッドのロジックをモデルに移行しました。