### PR TITLE
refac:メソッドチェーンをmodelに分離

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,14 +1,13 @@
 class HomesController < ApplicationController
   skip_before_action :authenticate_user!
   def index
-    @recent_proverbs = Proverb.titled.order(created_at: :desc).limit(10)
+    @recent_proverbs = Proverb.recent_limit_10
 
     @recent_proverb_items =
       @recent_proverbs.includes(proverb_contributors: :user).map do |p|
         user_names =
           p.proverb_contributors
            .map { |pc| pc.user.name }
-           .uniq      # 予防的処理
 
         {
           title: p.title,

--- a/app/models/proverb.rb
+++ b/app/models/proverb.rb
@@ -19,6 +19,10 @@ class Proverb < ApplicationRecord
 
   scope :titled, -> { where.not(title: [ nil, "" ]) }
   scope :recent, -> { order(created_at: :desc) }
+  scope :recent_limit_10, ->(limit = 10) {
+    titled.recent.limit(limit)
+  }
+
 
   # 指定したリアクション数でランキング付けする
   scope :ranked_by, ->(kind) {


### PR DESCRIPTION
1. home#indexアクションに書いていたメソッドチェーンをproverbモデルに分離しました。

2. ことわざからnameを取り出すときにuniqを使っていたのですが、やめました。
なぜなら、同じユーザー名が仮に作ったときに一つしか出ないからです。