### PR TITLE
add:roomsテーブルのowner_idをbigintに変更

### DIFF
--- a/db/migrate/20260114103436_change_rooms_owner_id_to_bigint.rb
+++ b/db/migrate/20260114103436_change_rooms_owner_id_to_bigint.rb
@@ -1,0 +1,18 @@
+class ChangeRoomsOwnerIdToBigint < ActiveRecord::Migration[7.2]
+  def up
+    # 外部キーを外す
+    remove_foreign_key :rooms, column: :owner_id
+
+    # 型変更
+    change_column :rooms, :owner_id, :bigint, null: false
+
+    # 外部キーを付け直す
+    add_foreign_key :rooms, :users, column: :owner_id
+  end
+
+  def down
+    remove_foreign_key :rooms, column: :owner_id
+    change_column :rooms, :owner_id, :integer, null: false
+    add_foreign_key :rooms, :users, column: :owner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_06_105259) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_14_103436) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -146,7 +146,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_06_105259) do
   end
 
   create_table "rooms", force: :cascade do |t|
-    t.integer "owner_id", null: false
+    t.bigint "owner_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
# 概要
roomsテーブルのower_idをintegerからbigintに変更

# 実施内容
コンテスト機能でowner_idをbigintとして使う必要が出てきたので、integerからbigintに変更しました。