### PR TITLE
refac:不要なdistinctを削除

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,7 +12,7 @@ class Comment < ApplicationRecord
   private
   def create_notification_comment
     # コメントした本人は除外する
-    recipients = proverb.users.where.not(id: user_id).distinct
+    recipients = proverb.users.where.not(id: user_id)
     return if recipients.blank?
 
     recipients.find_each do |recipient|


### PR DESCRIPTION
# 概要
不要なdistinctを削除しました。
仕様上同じuser.idが入ることはなく、将来的にも不要なため削除しました。
また、パフォーマンスの観点も考慮して削除しました。